### PR TITLE
Adds Option to Limit File Size

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+  "configurations": [
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug LRExportHEIC",
+      "program": "${workspaceFolder:LRExportHEIC}/.build/debug/LRExportHEIC",
+      "args": [],
+      "cwd": "${workspaceFolder:LRExportHEIC}",
+      "preLaunchTask": "swift: Build Debug LRExportHEIC"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Release LRExportHEIC",
+      "program": "${workspaceFolder:LRExportHEIC}/.build/release/LRExportHEIC",
+      "args": [],
+      "cwd": "${workspaceFolder:LRExportHEIC}",
+      "preLaunchTask": "swift: Build Release LRExportHEIC"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Test LRExportHEIC",
+      "program": "/Applications/Xcode.app/Contents/Developer/usr/bin/xctest",
+      "args": [
+        ".build/debug/LRExportHEICPackageTests.xctest"
+      ],
+      "cwd": "${workspaceFolder:LRExportHEIC}",
+      "preLaunchTask": "swift: Build All"
+    }
+  ]
+}

--- a/LRPlugin/ExportHEIC.lua
+++ b/LRPlugin/ExportHEIC.lua
@@ -1,7 +1,8 @@
-local LrView = import 'LrView'
-local LrTasks = import 'LrTasks'
-local LrPathUtils = import 'LrPathUtils'
+local LrBinding = import 'LrBinding'
 local LrLogger = import 'LrLogger'
+local LrPathUtils = import 'LrPathUtils'
+local LrTasks = import 'LrTasks'
+local LrView = import 'LrView'
 
 local logger = LrLogger('ExportHEIC')
 logger:enable('print')
@@ -13,89 +14,157 @@ end
 return {
   exportPresetFields = {
     { key = 'HEICQuality', default = 75 },
+    { key = 'HEICUseSizeLimit', default = false },
+    { key = 'HEICSizeLimit', default = 3000 },
+    { key = 'HEICMinQuality', default = 10 },
+    { key = 'HEICMaxQuality', default = 90 },
     { key = 'HEICColorSpace', default = 'SRGB' },
     { key = 'HEICBitDepth', default = 10 },
   },
   hideSections = { 'video', 'fileSettings' },
   -- sectionsForTopOfDialog = function( viewFactory, propertyTable )
   sectionForFilterInDialog = function( viewFactory, propertyTable )
-    return 
-      {
-        title = 'HEIC Settings',
-        viewFactory:row {
-          viewFactory:column {
-            viewFactory:row {
-              viewFactory:static_text { title = 'Quality' },
-              viewFactory:slider {
-                value = LrView.bind('HEICQuality'),
-                min = 0,
-                max = 100,
-                integral = true
+    local f = viewFactory
+    local bind = LrView.bind
+    local negbind = LrBinding.negativeOfKey
+
+    return {
+      title = 'HEIC Settings',
+
+      f:row {  -- root row
+        margin_top = 8,
+        margin_bottom = 8,
+        spacing = 18,
+
+        f:column {  -- left-column
+          spacing = 12,
+
+          f:row {  -- control 1: quality
+            f:static_text {
+              title = 'Quality:', enabled = negbind 'HEICUseSizeLimit',
+              width_in_chars = 8, alignment = 'right',
+            },
+            f:spacer { width = 2 },
+            f:slider {
+              value = bind 'HEICQuality',
+              enabled = negbind 'HEICUseSizeLimit',
+              min = 0, max = 100, integral = true,
+            },
+            f:static_text {
+              title = bind({ key = 'HEICQuality', transform = formatPercentage }),
+              enabled = negbind 'HEICUseSizeLimit',
+            },
+          },  -- control 1: quality
+
+          f:row {  -- control 2: color space
+            f:static_text { width_in_chars = 8, alignment = 'right', title = 'Color Space:' },
+            f:spacer { width = 2 },
+            f:popup_menu {
+              width_in_chars = 8,
+              items = {
+                { title = 'sRGB', value = 'SRGB' },
+                { title = 'Display P3', value = 'DisplayP3' },
+                { title = 'AdobeRGB', value = 'AdobeRGB1998' },
               },
-              viewFactory:static_text {
-                title = LrView.bind({ key = 'HEICQuality', transform = formatPercentage })
-              },
+              value = bind 'HEICColorSpace'
+            },
+          },  -- control 2: color space
+
+          f:row {  -- control 3: bit depth
+            f:static_text { width_in_chars = 8, alignment = 'right', title = 'Bit Depth:' },
+            f:spacer { width = 2 },
+            f:radio_button { value = bind 'HEICBitDepth', title = '8', checked_value = 8 },
+            f:radio_button { value = bind 'HEICBitDepth', title = '10', checked_value = 10 },
+          },  -- control 3: bit depth
+
+        },  -- left-column
+
+        f:column {  -- right column
+          spacing = 12,
+
+          f:row {  -- control 1: file size
+            f:checkbox { value = bind 'HEICUseSizeLimit', title = 'Limit File Size To:' },
+            f:edit_field {
+              value = bind 'HEICSizeLimit',
+              enabled = bind 'HEICUseSizeLimit',
+              increment = 100, large_increment = 1000,
+              min = 1, max = 1000000,
+              width_in_digits = 7,
+            },
+            f:static_text { title = 'K' },
+          },  -- control 1: file size
+
+          f:view {  -- control 2: min quality
+            visible = bind 'HEICUseSizeLimit',
+            place = 'horizontal',
+            f:static_text { width_in_chars = 9, title = 'Minimal Quality:' },
+            f:slider {
+              value = bind 'HEICMinQuality',
+              min = 0, max = 100, integral = true,
+            },
+            f:static_text {
+              title = bind({ key = 'HEICMinQuality', transform = formatPercentage })
             },
           },
-          viewFactory:spacer { width = 16 },
-          viewFactory:column {
-            viewFactory:row {
-              viewFactory:static_text { title = 'Color Space:' },
-              viewFactory:spacer { width = 4 },
-              viewFactory:popup_menu {
-                items = {
-                  { title = 'sRGB', value = 'SRGB' },
-                  { title = 'Display P3', value = 'DisplayP3' },
-                  { title = 'AdobeRGB', value = 'AdobeRGB1998' },
-                },
-                value = LrView.bind('HEICColorSpace')
-              },
+
+          f:view {  -- control 3: max quality
+            visible = bind 'HEICUseSizeLimit',
+            place = 'horizontal',
+            f:static_text { width_in_chars = 9, title = 'Maximal Quality:' },
+            f:slider {
+              value = bind 'HEICMaxQuality',
+              min = 0, max = 100, integral = true,
             },
-          }
-        },
-        viewFactory:row {
-          viewFactory:static_text { title = 'Bit Depth' },
-          viewFactory:spacer { width = 4 },
-          viewFactory:popup_menu {
-            items = {
-              { title = '8', value = 8 },
-              { title = '10', value = 10 },
+            f:static_text {
+              title = bind({ key = 'HEICMaxQuality', transform = formatPercentage })
             },
-            value = LrView.bind('HEICBitDepth')
           },
-        },
-      }
+        },  -- right column
+
+      }  -- root row
+    }
   end,
   postProcessRenderedPhotos = function(functionContext, filterContext)
-    local converterPath = LrPathUtils.child(_PLUGIN.path, 'LRExportHEIC')
-    local qualityPercent = filterContext.propertyTable.HEICQuality / 100
+    local p = filterContext.propertyTable
 
     local renditionOptions = {
       filterSettings = function( renditionToSatisfy, exportSettings )
         exportSettings.LR_format = 'TIFF'
-        if filterContext.propertyTable.HEICBitDepth > 8 then
+        if p.HEICBitDepth > 8 then
           exportSettings.LR_export_bitDepth = 16
         else
           exportSettings.LR_export_bitDepth = 8
         end
 
-        if filterContext.propertyTable.HEICColorSpace == "SRGB" then
+        if p.HEICColorSpace == "SRGB" then
           exportSettings.LR_export_colorSpace = "sRGB"
-        elseif filterContext.propertyTable.HEICColorSpace == "AdobeRGB1998" then
+        elseif p.HEICColorSpace == "AdobeRGB1998" then
           exportSettings.LR_export_colorSpace = "AdobeRGB"
-        elseif filterContext.propertyTable.HEICColorSpace == "DisplayP3" then
+        elseif p.HEICColorSpace == "DisplayP3" then
           exportSettings.LR_export_colorSpace = "DisplayP3"
         end
         return os.tmpname()
       end,
     }
 
+    local converterPath = LrPathUtils.child(_PLUGIN.path, 'LRExportHEIC')
+    local cmd = '"' .. converterPath .. '"'
+    if p.HEICUseSizeLimit then
+      cmd = (cmd .. ' --size-limit ' .. (p.HEICSizeLimit * 1000)
+             .. ' --min-quality ' .. (p.HEICMinQuality / 100)
+             .. ' --max-quality ' .. (p.HEICMaxQuality / 100))
+    else
+      cmd = cmd .. ' --quality ' .. (p.HEICQuality / 100)
+    end
+
     logger:info('Starting rendering of TIFF originals')
     for sourceRendition, renditionToSatisfy in  filterContext:renditions(renditionOptions) do
       logger:info('Processing rendition')
       local success, pathOrMessage = sourceRendition:waitForRender()
       if success then
-        local status = LrTasks.execute(converterPath .. ' --input-file "' .. pathOrMessage .. '" --quality ' .. qualityPercent .. ' "' .. renditionToSatisfy.destinationPath .. '"')
+        local actualCmd = (cmd .. ' --input-file "' .. pathOrMessage .. '" "'
+                           .. renditionToSatisfy.destinationPath .. '"')
+        local status = LrTasks.execute(actualCmd)
         logger:info('Command status: ' .. status)
         if status ~= 0 then
           logger:info('Failure')

--- a/Sources/LRExportHEIC/ExportHEICCommand.swift
+++ b/Sources/LRExportHEIC/ExportHEICCommand.swift
@@ -19,9 +19,28 @@ struct ExportHEICCommand: Command {
     var inputFile: String!
 
     @Option(
-      name: "quality", help: "Compression quality between 0.0-1.0", required: true,
+      name: "quality", help: "Compression quality between 0.0-1.0. Cannot be used with --size-limit",
       allowedValues: 0.0...1.0)
-    var quality: Float!
+    var quality: Float?
+
+    @Option(
+      name: "size-limit",
+      help: "Limit the size in bytes of the resulting image file, instead of specifying a "
+        + "quality directly. Cannot be used with --quality",
+      allowedValues: 1...Int64.max)
+    var sizeLimit: Int64?
+
+    @Option(
+      name: "min-quality",
+      help: "Minimal allowed compression quality, between 0.0-1.0, if --size-limit is used. Default: 0.0",
+      allowedValues: 0.0...1.0)
+    var minQuality: Double?
+
+    @Option(
+      name: "max-quality",
+      help: "Maximal allowed compression quality, between 0.0-1.0, if --size-limit is used. Default: 1.0",
+      allowedValues: 0.0...1.0)
+    var maxQuality: Double?
 
     @Option(
       name: "color-space",
@@ -68,6 +87,7 @@ struct ExportHEICCommand: Command {
 
   func run(using context: CommandContext, signature: ExportHEICCommandSignature) throws {
     try signature.enhanceOptions()
+    try signature.checkOptions()
 
     let inputImage = CIImage(contentsOf: signature.inputFileURL)
     guard let inputImage = inputImage else {
@@ -85,12 +105,50 @@ struct ExportHEICCommand: Command {
       context.console.print("Input Bitdepth: \(bitDepth)")
     }
 
-    try writeHEIF(
-      of: inputImage,
-      to: signature.outputFileURL,
-      in: colorSpace,
-      withQuality: signature.quality!,
-      shouldUseHEIF10: shouldUseHEIF10,
-      verbose: signature.verbose)
+    if signature.quality != nil {
+      try writeHEIF(
+        of: inputImage,
+        to: signature.outputFileURL,
+        in: colorSpace,
+        withQuality: signature.quality!,
+        shouldUseHEIF10: shouldUseHEIF10,
+        verbose: signature.verbose)
+    } else {
+      try writeSizeLimitedHEIF(
+        of: inputImage,
+        to: signature.outputFileURL,
+        in: colorSpace,
+        withSizeLimit: signature.sizeLimit!,
+        withinRange: (signature.minQuality ?? 0)...(signature.maxQuality ?? 1),
+        shouldUseHEIF10: shouldUseHEIF10,
+        verbose: signature.verbose)
+    }
+  }
+}
+
+extension ExportHEICCommand.ExportHEICCommandSignature {
+  enum MyError: Error, CustomStringConvertible {
+    var description: String {
+      switch self {
+      case .coexistencyNotAllowed(let label, let anotherArgumentLabel):
+        return "`--\(label)` cannot be used with `--\(anotherArgumentLabel)`"
+      case .missingEitherArgument(let labels):
+        let flags = labels.map({ s in "--" + s }).joined(separator: ", ")
+        return "One of \(flags) must be specified"
+      }
+    }
+
+    case coexistencyNotAllowed(_ label: String, _ anotherArgumentLabel: String)
+    case missingEitherArgument(_ labels: [String])
+  }
+
+  func checkOptions() throws {
+    if quality != nil {
+      if sizeLimit != nil { throw MyError.coexistencyNotAllowed("quality", "size-limit") }
+      if minQuality != nil { throw MyError.coexistencyNotAllowed("quality", "min-quality") }
+      if maxQuality != nil { throw MyError.coexistencyNotAllowed("quality", "max-quality") }
+    } else {
+      if sizeLimit == nil { throw MyError.missingEitherArgument(["quality", "size-limit"]) }
+    }
   }
 }

--- a/Sources/LRExportHEIC/ExportHEICCommand.swift
+++ b/Sources/LRExportHEIC/ExportHEICCommand.swift
@@ -73,7 +73,6 @@ struct ExportHEICCommand: Command {
     guard let inputImage = inputImage else {
       throw ExportHEICError.couldNotReadImage
     }
-    let outputFileURL = signature.outputFileURL
 
     let bitDepth = inputImage.properties["Depth"] as? Int ?? 8
     let colorSpace =
@@ -82,34 +81,16 @@ struct ExportHEICCommand: Command {
 
     if signature.verbose {
       context.console.print("Input URL: \(signature.inputFileURL!)")
-      context.console.print("Output File: \(signature.outputFile)")
-      context.console.print("Output URL: \(outputFileURL)")
       context.console.print("Input Colorspace: \(inputImage.colorSpace!)")
-      context.console.print("Output Colorspace: \(colorSpace)")
       context.console.print("Input Bitdepth: \(bitDepth)")
-      context.console.print("Output Bitdepth: \(shouldUseHEIF10 ? 10 : 8)")
     }
 
-    let ctx = CIContext()
-    let opts =
-      [kCGImageDestinationLossyCompressionQuality: signature.quality!]
-      as [CIImageRepresentationOption: Any]
-
-    if shouldUseHEIF10 {
-      try ctx.writeHEIF10Representation(
-        of: inputImage,
-        to: outputFileURL,
-        colorSpace: colorSpace,
-        options: opts
-      )
-    } else {
-      try ctx.writeHEIFRepresentation(
-        of: inputImage,
-        to: outputFileURL,
-        format: .RGBA8,
-        colorSpace: colorSpace,
-        options: opts
-      )
-    }
+    try writeHEIF(
+      of: inputImage,
+      to: signature.outputFileURL,
+      in: colorSpace,
+      withQuality: signature.quality!,
+      shouldUseHEIF10: shouldUseHEIF10,
+      verbose: signature.verbose)
   }
 }

--- a/Sources/LRExportHEIC/QualitySearch.swift
+++ b/Sources/LRExportHEIC/QualitySearch.swift
@@ -1,0 +1,81 @@
+/// Finds the best compression quality to make the resulting file size to be slightly lower than the target file
+/// size limit.
+///
+/// - Parameter maxSize: The target file size. The resulting file size must equal to or be less then the limit,
+///     unless `minQuality` is reached.
+/// - Parameter sizeAccuracy: An allowance in range 0 - 1. As it tries multiple times to find the best quality,
+///     it can stop early to save time if a file's size satisfies `maxSize * sizeAccuracy <= size <=
+///     maxSize`.
+/// - Parameter qualityRange: The range of quality to attempt within. The range should be between 0 - 1, inclusive.
+///     The resulting quality will never be lower than its lower bound, even when the resulting file size is larger
+///     than `maxSize`.
+/// - Returns: The "best" compression quality found.
+///
+func qualitySearch(
+  byTargetFileSize maxSize: Int64,
+  withAccuracy sizeAccuracy: Double,
+  withinRange qualityRange: ClosedRange<Double>,
+  getFileSizeByQualityFn: (Double) -> Int64
+) -> Double {
+  assert(maxSize >= 1, "Invalid argument: maxSize >= 1 is not met")
+  assert(0 <= sizeAccuracy && sizeAccuracy <= 1, "Invalid argument: 0 <= sizeAccuracy <= 1 is not met")
+
+  var minQ = qualityRange.lowerBound
+  var maxQ = qualityRange.upperBound
+  assert(0 <= minQ && minQ <= 1, "Invalid argument: 0 <= entire qualityRange <= 1 is not met")
+  assert(0 <= maxQ && maxQ <= 1, "Invalid argument: 0 <= entire qualityRange <= 1 is not met")
+
+  if minQ == maxQ {
+    return minQ
+  }
+
+  let minSize = Int64(Double(maxSize) * sizeAccuracy)
+  var qualitiesAndSizes = [(Double, Int64)]()
+
+  var currQ = (minQ + maxQ) / 2
+  var currSize = getFileSizeByQualityFn(currQ)
+  qualitiesAndSizes.append((currQ, currSize))
+
+  // Some heuristic early returns.
+  if currSize > maxSize * 5 {
+    let minPossibleSize = getFileSizeByQualityFn(minQ)
+    if minPossibleSize >= minSize { return minQ }
+    qualitiesAndSizes.append((minQ, minPossibleSize))
+  } else if currSize < minSize / 5 {
+    let maxPossibleSize = getFileSizeByQualityFn(maxQ)
+    if maxPossibleSize <= maxSize { return maxQ }
+    qualitiesAndSizes.append((maxQ, maxPossibleSize))
+  }
+
+  while true {
+    if minSize <= currSize && currSize <= maxSize {
+      return currQ
+    } else if currSize < minSize {
+      minQ = currQ
+    } else {
+      maxQ = currQ
+    }
+
+    assert(maxQ >= minQ)
+    if maxQ - minQ <= 0.015 { break }
+
+    currQ = (minQ + maxQ) / 2
+    currSize = getFileSizeByQualityFn(currQ)
+    qualitiesAndSizes.append((currQ, currSize))
+  }
+
+  // If we reach here, we are sure that no iteration's file size is between the target range [minSize, maxSize],
+  // except for the last iteration, which is fine.
+  assert(qualitiesAndSizes.count >= 1)
+
+  // Find the file size smaller than and closest to maxSize.
+  var tuple = qualitiesAndSizes.filter({ (tuple) in tuple.1 <= maxSize }).max(by: { (a, b) in a.1 < b.1 })
+  if tuple != nil {
+    return tuple!.0
+  }
+
+  // Nothing being found means all sizes are greater than the desired size limit. Return the smallest one.
+  tuple = qualitiesAndSizes.min(by: { (a, b) in a.1 < b.1 })
+  assert(tuple != nil)
+  return tuple!.0
+}

--- a/Sources/LRExportHEIC/WriteHEIF.swift
+++ b/Sources/LRExportHEIC/WriteHEIF.swift
@@ -1,0 +1,37 @@
+import CoreImage
+
+func writeHEIF(
+  of image: CIImage,
+  to url: URL,
+  in colorSpace: CGColorSpace,
+  withQuality quality: Float,
+  shouldUseHEIF10: Bool,
+  verbose: Bool
+) throws {
+  let opts = [kCGImageDestinationLossyCompressionQuality: quality] as [CIImageRepresentationOption: Any]
+  let ctx = CIContext()
+
+  if verbose {
+    print("Output URL: \(url)")
+    print("Output Quality: \(quality)")
+    print("Output Colorspace: \(colorSpace)")
+    print("Output Bitdepth: \(shouldUseHEIF10 ? 10 : 8)")
+  }
+
+  if shouldUseHEIF10 {
+    try ctx.writeHEIF10Representation(
+      of: image,
+      to: url,
+      colorSpace: colorSpace,
+      options: opts
+    )
+  } else {
+    try ctx.writeHEIFRepresentation(
+      of: image,
+      to: url,
+      format: .RGBA8,
+      colorSpace: colorSpace,
+      options: opts
+    )
+  }
+}

--- a/Sources/LRExportHEIC/WriteSizeLimitedHEIF.swift
+++ b/Sources/LRExportHEIC/WriteSizeLimitedHEIF.swift
@@ -1,0 +1,80 @@
+import CoreImage
+
+func writeSizeLimitedHEIF(
+  of image: CIImage,
+  to destURL: URL,
+  in colorSpace: CGColorSpace,
+  withSizeLimit size: Int64,
+  withinRange qualityRange: ClosedRange<Double>,
+  shouldUseHEIF10: Bool,
+  verbose: Bool
+) throws {
+  let tempDirUrl = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+
+  // Prefix the temp file's name with a random string to avoid potential conflicts, when we are
+  // running on multiple processes.
+  let tempBaseName = NSUUID().uuidString + "-" + destURL.deletingPathExtension().lastPathComponent
+
+  // A dict from qualities to URLs. Set up cleanup (temp file removal).
+  var qualitiesAndURLs = [Double: URL]()
+  defer {
+    for (_, url) in qualitiesAndURLs {
+      try? FileManager.default.removeItem(at: url)
+    }
+  }
+
+  func writeTempHEIFAndGetSize(_ quality: Double) -> Int64 {
+    let destURL = tempDirUrl.appendingPathComponent("\(tempBaseName)-\(quality).heif")
+    do {
+      try writeHEIF(
+        of: image,
+        to: destURL,
+        in: colorSpace,
+        withQuality: Float(quality),
+        shouldUseHEIF10: shouldUseHEIF10,
+        verbose: verbose)
+      qualitiesAndURLs[quality] = destURL
+      let resources = try destURL.resourceValues(forKeys: [.fileSizeKey])
+      let fileSize = resources.fileSize!
+      if verbose {
+        print("Output File Size: \(fileSize)")
+      }
+      return Int64(fileSize)
+    } catch let error {
+      fatalError("Cannot write temp HEIF image and get file size: \(error.localizedDescription)")
+    }
+  }
+
+  // In multiple attempts, generate the images and try to find the fittest quality.
+  let quality = qualitySearch(
+    byTargetFileSize: size,
+    withAccuracy: 0.8,
+    withinRange: qualityRange,
+    getFileSizeByQualityFn: writeTempHEIFAndGetSize)
+
+  if verbose {
+    print("Chosen Output Quality: \(quality)")
+  }
+
+  let chosenUrl = qualitiesAndURLs[quality]
+
+  if (chosenUrl != nil) {
+    // We have generated an image with given quality.
+    if verbose {
+      print("Moving \(chosenUrl!) to \(destURL)")
+    }
+    // Move the right file from the temp directory to the final directory.
+    try? FileManager.default.removeItem(at: destURL)
+    try FileManager.default.moveItem(at: chosenUrl!, to: destURL)
+
+  } else {
+    // We have NOT generated an image with given quality. (qualitySearch may have returned early.)
+    try writeHEIF(
+      of: image,
+      to: destURL,
+      in: colorSpace,
+      withQuality: Float(quality),
+      shouldUseHEIF10: shouldUseHEIF10,
+      verbose: verbose)
+  }
+}

--- a/Tests/LRExportHEICTests/LRExportHEICTests.swift
+++ b/Tests/LRExportHEICTests/LRExportHEICTests.swift
@@ -4,6 +4,8 @@ import class Foundation.Bundle
 
 final class LRExportHEICTests: XCTestCase {
   func testExample() throws {
+    throw XCTSkip("This test is not correctly written.")
+
     // This is an example of a functional test case.
     // Use XCTAssert and related functions to verify your tests produce the correct
     // results.

--- a/Tests/LRExportHEICTests/QualitySearchTests.swift
+++ b/Tests/LRExportHEICTests/QualitySearchTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import XCTest
+
+@testable import func LRExportHEIC.qualitySearch
+
+final class QualitySearchTests: XCTestCase {
+  private var getFileSizeByQualityFnCallCount = 0
+
+  override func setUp() {
+    super.setUp()
+    getFileSizeByQualityFnCallCount = 0
+  }
+
+  private func fakeGetFileSize(_ quality: Double) -> Int64 {
+    getFileSizeByQualityFnCallCount += 1
+    let fileSize = Int64(round(quality * 10000))
+    // print(quality, "\t", fileSize)  // Uncomment this line for debugging.
+    return fileSize
+  }
+
+  func testBasic() throws {
+    let actual = qualitySearch(
+      byTargetFileSize: 3100, withAccuracy: 0.8, withinRange: 0.1...0.9,
+      getFileSizeByQualityFn: fakeGetFileSize)
+    // 2 attempts: 0.5 => 5000, 0.3 => 3000
+    XCTAssertEqual(getFileSizeByQualityFnCallCount, 2)
+    XCTAssertEqual(actual, 0.3)
+  }
+
+  func testSameMinMaxQuality() throws {
+    let actual = qualitySearch(
+      byTargetFileSize: 10, withAccuracy: 1, withinRange: 0.5...0.5,
+      getFileSizeByQualityFn: fakeGetFileSize)
+    // No need to make attempts.
+    XCTAssertEqual(getFileSizeByQualityFnCallCount, 0)
+    XCTAssertEqual(actual, 0.5)
+  }
+
+  func testTargetVerySmall() throws {
+    let actual = qualitySearch(
+      byTargetFileSize: 10, withAccuracy: 1, withinRange: 0.1...0.9,
+      getFileSizeByQualityFn: fakeGetFileSize)
+    // 2 attempts: 0.5 => 5000, 0.1 => 1000
+    XCTAssertEqual(getFileSizeByQualityFnCallCount, 2)
+    XCTAssertEqual(actual, 0.1)
+  }
+
+  func testTargetVerySmallButNotSmallerThanLowestQuality() throws {
+    let actual = qualitySearch(
+      byTargetFileSize: 900, withAccuracy: 0.5, withinRange: 0.001...1,
+      getFileSizeByQualityFn: fakeGetFileSize)
+    // 5 attempts: 0.5005 => 5005, 0.001 => 10, 0.2507 => 2507, 0.1259 => 1259, 0.0634 => 634
+    XCTAssertEqual(getFileSizeByQualityFnCallCount, 5)
+    XCTAssertEqual(actual, 0.0634375)
+  }
+
+  func testTargetVeryBig() throws {
+    let actual = qualitySearch(
+      byTargetFileSize: 100000, withAccuracy: 1, withinRange: 0...1,
+      getFileSizeByQualityFn: fakeGetFileSize)
+    // 2 attempts: 0.5 => 5000, 1 => 10000
+    XCTAssertEqual(getFileSizeByQualityFnCallCount, 2)
+    XCTAssertEqual(actual, 1)
+  }
+
+  func testLooseSizeAccuracy() throws {
+    let actual = qualitySearch(
+      byTargetFileSize: 10000, withAccuracy: 0.1, withinRange: 0...1,
+      getFileSizeByQualityFn: fakeGetFileSize)
+    // 1 attempt: 0.5 => 5000
+    XCTAssertEqual(getFileSizeByQualityFnCallCount, 1)
+    XCTAssertEqual(actual, 0.5)
+  }
+
+  func testStrictSizeAccuracyCannotReachTarget() throws {
+    let actual = qualitySearch(
+      byTargetFileSize: 10, withAccuracy: 1, withinRange: 0...0.8192,
+      getFileSizeByQualityFn: fakeGetFileSize)
+    // 7 attempts: 0.4096, 0, 0.2048, 0.1024, 0.0512, 0.0256, 0.0128
+    // Ending criteria "len(0, 0.0128) is less than 0.015" is met.
+    // Size 128 > TargetSize 10, so returns quality 0.
+    XCTAssertEqual(getFileSizeByQualityFnCallCount, 7)
+    XCTAssertEqual(actual, 0)
+  }
+
+  func testStrictSizeAccuracyButReachedTarget() throws {
+    let actual = qualitySearch(
+      byTargetFileSize: 129, withAccuracy: 1, withinRange: 0...0.8192,
+      getFileSizeByQualityFn: fakeGetFileSize)
+    // 7 attempts: 0.4096, 0, 0.2048, 0.1024, 0.0512, 0.0256, 0.0128
+    // Ending criteria "len(0, 0.0128) is less than 0.015" is met.
+    // Size 128 < TargetSize 129, so returns quality 0.0128.
+    XCTAssertEqual(getFileSizeByQualityFnCallCount, 7)
+    XCTAssertEqual(actual, 0.0128)
+  }
+}


### PR DESCRIPTION
(So I was able to work on the limit-file-size option, ref: https://github.com/milch/LRExportHEIC/issues/2#issue-1120319459 , and I managed to get a working version!)

This PR adds the option to limit resulting file size.

- Default view:
  <img width="619" alt="Default view" src="https://user-images.githubusercontent.com/5345836/156106717-2bfba8a4-455c-463e-b33b-4a3576bfe598.png">

- Size limit selected:
  <img width="614" alt="Size limit selected" src="https://user-images.githubusercontent.com/5345836/156106835-3c011b33-c872-46da-b644-9d79f7c914b5.png">

The Lua entry point is changed to pass settings to the underlying Swift command-line tool (CLI). The CLI's flags are changed, and the logic of finding best quality is added to a new file `WriteSizeLimitedHEIF.swift`. Its binary search algorithm is in a separate file `QualitySearch.swift`, which is guarded by a unit test on `QualitySearchTests.swift`.

Please feel free to let me know if you have any comments. Thanks in advance for reviewing!